### PR TITLE
Scorer and Index Producer

### DIFF
--- a/tools/ProvenanceScorer/ProvenanceFilteringScorerReportByNodeType.py
+++ b/tools/ProvenanceScorer/ProvenanceFilteringScorerReportByNodeType.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python2
+
+import sys
+import os
+lib_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../lib")
+sys.path.append(lib_path)
+
+import json
+import argparse
+import pandas as pd
+import errno
+import collections
+
+from ProvenanceMetrics import *
+
+def err_quit(msg, exit_status=1):
+    print(msg)
+    exit(exit_status)
+
+def load_json(json_fn):
+    try:
+        with open(json_fn, 'r') as json_f:
+            return json.load(json_f)
+    except IOError as ioerr:
+        err_quit("{}. Aborting!".format(ioerr))
+
+def load_csv(csv_fn, sep="|"):
+    try:
+        return pd.read_csv(csv_fn, sep)
+    except IOError as ioerr:
+        err_quit("{}. Aborting!".format(ioerr))
+
+def mkdir_p(path):
+    try:
+        os.makedirs(path)
+    except OSError as exc:
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            err_quit("{}. Aborting!".format(exc))
+        
+# Returns ordered array of named tuples representing nodes
+def system_out_to_ordered_nodes(system_out):
+    node_w_confidence = collections.namedtuple('node_w_confidence', [ 'confidence', 'file' ])
+    node_set_w_confidence = [ node_w_confidence(n["nodeConfidenceScore"], n["file"]) for n in system_out["nodes"] ]
+    node_set_w_confidence.sort(reverse=True)
+    return node_set_w_confidence
+
+def build_provenancefiltering_agg_output_df():
+    df = pd.DataFrame(columns=[
+                               "MeanNodeRecall@50",
+                               "MeanNodeRecall@100",
+                               "MeanNodeRecall@200",
+                               "BaseMeanNodeRecall@50",
+                               "BaseMeanNodeRecall@100",
+                               "BaseMeanNodeRecall@200",
+                               "DonorMeanNodeRecall@50",
+                               "DonorMeanNodeRecall@100",
+                               "DonorMeanNodeRecall@200",
+                               "InterMeanNodeRecall@50",
+                               "InterMeanNodeRecall@100",
+                               "InterMeanNodeRecall@200"
+                               ])
+    dtypes = { "MeanNodeRecall@50": float,
+               "MeanNodeRecall@100": float,
+               "MeanNodeRecall@200": float,
+               "BaseMeanNodeRecall@50": float,
+               "BaseMeanNodeRecall@100": float,
+               "BaseMeanNodeRecall@200": float,
+               "DonorMeanNodeRecall@50": float,
+               "DonorMeanNodeRecall@100": float,
+               "DonorMeanNodeRecall@200": float,
+               "InterMeanNodeRecall@50": float,
+               "InterMeanNodeRecall@100": float,
+               "InterMeanNodeRecall@200": float
+               }
+
+    # Setting column data type one by one as pandas doesn't offer a
+    # convenient way to do this
+    for col, t in dtypes.items():
+        df[col] = df[col].astype(t)
+
+    return df
+
+def build_provenancefiltering_output_df():
+    df = pd.DataFrame(columns=["JournalName",
+                               "ProvenanceProbeFileID",
+                               "ProvenanceOutputFileName",
+                               "NumSysNodes",
+                               "NumRefNodes",
+                               "NodeRecall@50",
+                               "NodeRecall@100",
+                               "NodeRecall@200",
+                               "BaseNodeRecall@50", 
+                               "BaseNodeRecall@100",
+                               "BaseNodeRecall@200",
+                               "DonorNodeRecall@50",
+                               "DonorNodeRecall@100",
+                               "DonorNodeRecall@200",
+                               "InterNodeRecall@50",
+                               "InterNodeRecall@100",
+                               "InterNodeRecall@200" ])
+    dtypes = { "JournalName": str,
+               "ProvenanceProbeFileID": str,
+               "ProvenanceOutputFileName": str,
+               "NumSysNodes": int,
+               "NumRefNodes": int,
+               "NodeRecall@50": float,
+               "NodeRecall@100": float,
+               "NodeRecall@200": float,
+               "BaseNodeRecall@50": float,
+               "BaseNodeRecall@100": float,
+               "BaseNodeRecall@200": float,
+               "DonorNodeRecall@50": float,
+               "DonorNodeRecall@100": float,
+               "DonorNodeRecall@200": float,
+               "InterNodeRecall@50": float,
+               "InterNodeRecall@100": float,
+               "InterNodeRecall@200": float }
+
+    # Setting column data type one by one as pandas doesn't offer a
+    # convenient way to do this
+    for col, t in dtypes.items():
+        df[col] = df[col].astype(t)
+
+    return df
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Score Medifor ProvenanceFiltering task output")
+    parser.add_argument("-t", "--skip-trial-disparity-check", help="Skip check for trial disparity between INDEX_FILE and SYSTEM_OUTPUT_FILE", action="store_true")
+    parser.add_argument("-o", "--output-dir", help="Output directory for scores", type=str, required=True)
+    parser.add_argument("-x", "--index-file", help="Task Index file", type=str, required=True)
+    parser.add_argument("-r", "--reference-file", help="Reference file", type=str, required=True)
+    parser.add_argument("-n", "--node-file", help="Node file", type=str, required=True)
+    parser.add_argument("-d", "--donor-node-file", help="Node file", type=str, required=True)
+    parser.add_argument("-b", "--base-node-file", help="Node file", type=str, required=True)
+    parser.add_argument("-i", "--inter-node-file", help="Node file", type=str, required=True)
+    parser.add_argument("-w", "--world-file", help="World file", type=str, required=True)
+    parser.add_argument("-R", "--reference-dir", help="Reference directory", type=str, required=True)
+    parser.add_argument("-s", "--system-output-file", help="System output file (i.e. <EXPID>.csv)", type=str, required=True)
+    parser.add_argument("-S", "--system-dir", help="System output directory where system output json files can be found", type=str, required=True)
+    args = parser.parse_args()
+
+    trial_index = load_csv(args.index_file)
+    ref_file = load_csv(args.reference_file)
+    nodes_file = load_csv(args.node_file)
+    #ref_node file by different nodes
+    donor_nodes_file = load_csv(args.donor_node_file)
+    base_nodes_file = load_csv(args.base_node_file)
+    inter_nodes_file = load_csv(args.inter_node_file)
+    world_index = load_csv(args.world_file)
+
+    system_output_index = load_csv(args.system_output_file)
+
+    def check_for_trial_disparity():
+        # detect missing trials
+        ref_probes = [ t.ProvenanceProbeFileID for t in trial_index.itertuples() ]
+        remaining_sys_probes = [ t.ProvenanceProbeFileID for t in system_output_index.itertuples() ]
+
+        missing_probes = []
+        for probe_id in ref_probes:
+            try:
+                remaining_sys_probes.remove(probe_id)
+            except ValueError:
+                missing_probes.append(probe_id)
+
+        errs = []
+        if len(missing_probes) > 0:
+            errs.append("Error, missing the following ProvenanceProbeFileIDs from the system output:\n{}".format("\n".join(map(lambda p: "\t" + p, missing_probes))))
+        if len(remaining_sys_probes) > 0:
+            errs.append("Error, extraneous ProvenanceProbeFileIDs in the system output:\n{}".format("\n".join(map(lambda p: "\t" + p, remaining_sys_probes))))
+
+        if len(errs) > 0:
+            errs.append("Aborting!")
+            err_quit("\n".join(errs))
+
+    if not args.skip_trial_disparity_check:
+        check_for_trial_disparity()
+            
+    trial_index_ref = pd.merge(trial_index, ref_file, on = "ProvenanceProbeFileID")
+    trial_index_ref_sysout = pd.merge(trial_index_ref, system_output_index, on = "ProvenanceProbeFileID")
+
+    world_nodes = pd.merge(nodes_file, world_index, on = "WorldFileID", how = "inner")
+    donor_world_nodes = pd.merge(donor_nodes_file, world_index, on = "WorldFileID", how = "inner")
+    base_world_nodes = pd.merge(base_nodes_file, world_index, on = "WorldFileID", how = "inner")
+    inter_world_nodes = pd.merge(inter_nodes_file, world_index, on = "WorldFileID", how = "inner")
+
+    output_records = build_provenancefiltering_output_df()
+        
+    for trial in trial_index_ref_sysout.itertuples():
+        system_out = load_json(os.path.join(args.system_dir, trial.ProvenanceOutputFileName))
+        
+        probe_node_wfn = trial.ProvenanceProbeFileName_x
+        world_set_nodes = { node.WorldFileName_x for node in world_nodes[world_nodes.ProvenanceProbeFileID == trial.ProvenanceProbeFileID].itertuples() }
+        donor_world_set_nodes = { node.WorldFileName_x \
+                for node in donor_world_nodes[donor_world_nodes.ProvenanceProbeFileID == trial.ProvenanceProbeFileID].itertuples() }
+        base_world_set_nodes = { node.WorldFileName_x \
+                for node in base_world_nodes[base_world_nodes.ProvenanceProbeFileID == trial.ProvenanceProbeFileID].itertuples() }
+        inter_world_set_nodes = { node.WorldFileName_x \
+                for node in inter_world_nodes[inter_world_nodes.ProvenanceProbeFileID == trial.ProvenanceProbeFileID].itertuples() }
+        world_set_nodes.add(probe_node_wfn)
+
+        ordered_sys_nodes = system_out_to_ordered_nodes(system_out)
+
+        out_rec = { "JournalName": trial.JournalName,
+                    "ProvenanceProbeFileID": trial.ProvenanceProbeFileID,
+                    "ProvenanceOutputFileName": trial.ProvenanceOutputFileName,
+                    "NumSysNodes": len(ordered_sys_nodes),
+                    "NumRefNodes": len(world_set_nodes) }
+
+        for n in [ 50, 100, 200 ]:
+            sys_nodes_at_n = { node.file for node in ordered_sys_nodes[0:n] }
+            out_rec.update({
+                             "DonorNodeRecall@{}".format(n): node_recall(donor_world_set_nodes, sys_nodes_at_n),
+                             "BaseNodeRecall@{}".format(n): node_recall(base_world_set_nodes, sys_nodes_at_n),
+                             "InterNodeRecall@{}".format(n): node_recall(inter_world_set_nodes, sys_nodes_at_n),
+                             "NodeRecall@{}".format(n): node_recall(world_set_nodes, sys_nodes_at_n) })
+            
+        output_records = output_records.append(pd.Series(out_rec), ignore_index=True)
+
+    output_agg_records = build_provenancefiltering_agg_output_df()
+    aggregated = { 
+                   "DonorMeanNodeRecall@50": output_records["DonorNodeRecall@50"].mean(),
+                   "DonorMeanNodeRecall@100": output_records["DonorNodeRecall@100"].mean(),
+                   "DonorMeanNodeRecall@200": output_records["DonorNodeRecall@200"].mean(),
+                   "BaseMeanNodeRecall@50": output_records["BaseNodeRecall@50"].mean(),
+                   "BaseMeanNodeRecall@100": output_records["BaseNodeRecall@100"].mean(),
+                   "BaseMeanNodeRecall@200": output_records["BaseNodeRecall@200"].mean(),
+                   "InterMeanNodeRecall@50": output_records["InterNodeRecall@50"].mean(),
+                   "InterMeanNodeRecall@100": output_records["InterNodeRecall@100"].mean(),
+                   "InterMeanNodeRecall@200": output_records["InterNodeRecall@200"].mean(),
+                   "MeanNodeRecall@50": output_records["NodeRecall@50"].mean(),
+                   "MeanNodeRecall@100": output_records["NodeRecall@100"].mean(),
+                   "MeanNodeRecall@200": output_records["NodeRecall@200"].mean(),
+                }
+    output_agg_records = output_agg_records.append(pd.Series(aggregated), ignore_index=True)
+
+    mkdir_p(args.output_dir)
+    try:
+        with open(os.path.join(args.output_dir, "trial_scores.csv"), 'w') as out_f:
+            output_records.to_csv(path_or_buf=out_f, sep="|", index=False)
+    except IOError as ioerr:
+        err_quit("{}. Aborting!".format(ioerr))
+    try:
+        with open(os.path.join(args.output_dir, "scores.csv"), 'w') as out_f:
+            output_agg_records.to_csv(path_or_buf=out_f, sep="|", index=False)
+    except IOError as ioerr:
+        err_quit("{}. Aborting!".format(ioerr))

--- a/tools/ProvenanceScorer/generateNodeRefByNodeType.py
+++ b/tools/ProvenanceScorer/generateNodeRefByNodeType.py
@@ -1,0 +1,125 @@
+# Python versions >= 2.7, requires `requests` library.
+
+"""
+The module is to generate different ref-node files for different type of nodes.
+Author: Xu Zhang
+Email: xu.zhang@columbia.edu
+
+Examples:
+    
+    Train the index and do the search    
+
+    >>> python generateNodeRefByNodeType.py --dataset_name=NC2017_Dev1_Beta4 
+
+"""
+
+
+from __future__ import print_function
+from urllib import urlretrieve
+import os, sys, errno, json, requests, argparse
+import csv
+import pandas as pd
+import shutil
+from tqdm import tqdm
+
+def err_quit(msg, exit_status=1):
+    print(msg)
+    exit(exit_status)
+
+def load_csv(csv_fn, sep="|"):
+    try:
+        return pd.read_csv(csv_fn, sep)
+    except IOError as ioerr:
+        err_quit("{}. Aborting!".format(ioerr))
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Generate Node Ref File')
+    parser.add_argument('--root_dir', type=str, default='/home/xuzhang/project/Medifor/data/', help='Directory to the dataset')
+    parser.add_argument('--dataset_name', type=str, default='NC2017_Dev1_Beta4', help='Name of the dataset')
+    parser.add_argument('--dataset_index', type=str, default='NC2017_Dev1', help='Index of the dataset')
+    args = parser.parse_args()
+    
+    root_dir =  args.root_dir
+    dataset_name =  args.dataset_name
+    dataset_index =  args.dataset_index
+
+    #read previous reference files
+    probe_index_file = load_csv(open('{}{}/reference/provenancefiltering/{}-provenancefiltering-ref.csv'.format(root_dir, dataset_name, dataset_index), 'rb'), '|')
+    node_file = load_csv(open('{}{}/reference/provenancefiltering/{}-provenancefiltering-ref-node.csv'.format(root_dir, dataset_name, dataset_index), 'rb'), '|')
+    node_dict = {}
+    
+    #build a dict for fast reference, deal with inconsistency between NodeWorldID and NodeJournalID
+    for  journal_id, file_id, file_name in zip(node_file['JournalNodeID'], node_file['WorldFileID'], node_file['WorldFileName']):
+        node_dict[journal_id] = (file_id,file_name)
+
+    #result file, which follow the old ref node format
+    base_ref_node_file = csv.writer(open('{}{}/reference/provenancefiltering/{}-provenancefiltering-base-ref-node.csv'.format(root_dir, dataset_name, dataset_index),
+        'wb'), delimiter='|')
+    base_ref_node_file.writerow(['ProvenanceProbeFileID','WorldFileID','WorldFileName','JournalNodeID'])
+
+    donor_ref_node_file = csv.writer(open('{}{}/reference/provenancefiltering/{}-provenancefiltering-donor-ref-node.csv'.format(root_dir,dataset_name,dataset_index),
+        'wb'), delimiter='|')
+    donor_ref_node_file.writerow(['ProvenanceProbeFileID','WorldFileID','WorldFileName','JournalNodeID'])
+
+    inter_ref_node_file = csv.writer(open('{}{}/reference/provenancefiltering/{}-provenancefiltering-inter-ref-node.csv'.format(root_dir,dataset_name,dataset_index),
+        'wb'), delimiter='|')
+    inter_ref_node_file.writerow(['ProvenanceProbeFileID','WorldFileID','WorldFileName','JournalNodeID'])
+
+    final_ref_node_file = csv.writer(open('{}{}/reference/provenancefiltering/{}-provenancefiltering-final-ref-node.csv'.format(root_dir,dataset_name,dataset_index),
+        'wb'), delimiter='|')
+    final_ref_node_file.writerow(['ProvenanceProbeFileID','WorldFileID','WorldFileName','JournalNodeID'])
+
+    for probe_id, journal_file_name in tqdm(zip(probe_index_file["ProvenanceProbeFileID"], probe_index_file['JournalFileName'])):
+        try:
+            with open('{}{}/{}'.format(root_dir, dataset_name, journal_file_name)) as json_file:    
+                json_data = json.load(json_file)
+        except:
+            print('Error to read {}'.format('%s.json' % (journal_file_name)))
+            continue
+        
+        node_data=json_data['nodes']
+        
+        base_index_list = []
+        inter_index_list = []
+        donor_index_list = []
+        final_index_list = []
+
+        for i in range(len(node_data)): 
+            if node_data[i]['nodetype']=='base':
+                base_index_list.append(i)
+            if node_data[i]['nodetype']=='final':
+                final_index_list.append(i)
+            if node_data[i]['nodetype']=='donor':
+                donor_index_list.append(i)
+            if node_data[i]['nodetype']=='interim':
+                inter_index_list.append(i)
+
+        provenanceProbeFileID = probe_id
+
+        for base_node_index in base_index_list:
+            baseFileID = node_data[base_node_index]['file'][:-4]
+            try:
+                base_ref_node_file.writerow([provenanceProbeFileID,node_dict[baseFileID][0],node_dict[baseFileID][1],baseFileID])
+            except:
+                pass
+
+        for final_node_index in final_index_list:
+            finalFileID = node_data[final_node_index]['file'][:-4]
+            try:
+                final_ref_node_file.writerow([provenanceProbeFileID,node_dict[finalFileID][0],node_dict[finalFileID][1],finalFileID])
+            except:
+                pass
+
+        for donor_node_index in donor_index_list:
+            donorFileID = node_data[donor_node_index]['file'][:-4]
+            try:
+                donor_ref_node_file.writerow([provenanceProbeFileID,node_dict[donorFileID][0],node_dict[donorFileID][1],donorFileID])
+            except:
+                pass
+
+        for inter_node_index in inter_index_list:
+            interFileID = node_data[inter_node_index]['file'][:-4]
+            try:
+                inter_ref_node_file.writerow([provenanceProbeFileID,node_dict[interFileID][0],node_dict[interFileID][1],interFileID])
+            except:
+                pass


### PR DESCRIPTION
A quick fix to support separate report by different node types.

Run generateNodeRefByNodeType.py to generate ref-node file for different images. 

Run ProvenanceFilteringScorerReportByNodeType.py to generate report.